### PR TITLE
Add depth limit to hinder infinite recursion in schemaConverter.ts

### DIFF
--- a/packages/spezi-firebase-utils/src/helpers/schemaConverter.ts
+++ b/packages/spezi-firebase-utils/src/helpers/schemaConverter.ts
@@ -31,9 +31,10 @@ export class SchemaConverter<Schema extends z.ZodTypeAny, Encoded> {
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-export type InferEncoded<Input> =
-  Input extends SchemaConverter<any, any> ? ReturnType<Input['encode']>
+export type InferEncoded<Input, Depth extends readonly unknown[] = []> =
+  Depth['length'] extends 10 ? never
+  : Input extends SchemaConverter<any, any> ? ReturnType<Input['encode']>
   : Input extends Lazy<SchemaConverter<any, any>> ?
-    ReturnType<Input['value']['encode']>
+    InferEncoded<Input['value'], [...Depth, unknown]>
   : never
 /* eslint-enable @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
# Add depth limit to hinder infinite recursion in schemaConverter.ts

## :recycle: Current situation & Problem
In packages/spezi-firebase-utils/src/helpers/schemaConverter.ts, there was a circular dependency caused by the InferEncoded type definition:
```
export type InferEncoded<Input> =
    Input extends SchemaConverter<any, any> ? ReturnType<Input['encode']>
    : Input extends Lazy<SchemaConverter<any, any>> ?
      ReturnType<Input['value']['encode']>
    : never
```

When TypeScript tries to resolve this type recursively (like eg with nested or self-referencing schemas), it can enter an infinite loop, because:
  1. `Input['value']['encode'] `references the Lazy<SchemaConverter> value property
  2. The `Lazy.value` getter returns T (which could be another SchemaConverter)
  3. This creates a cycle where TypeScript keeps trying to infer the return type of deeply nested converters

## :gear: Release Notes
N/A

## :books: Documentation
The solution adds a depth counter to prevent infinite recursion.

## :white_check_mark: Testing
N/A

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
