### PR TITLE
Make AllergyIntolerance.type optional, as defined in the spec

### DIFF
--- a/packages/spezi-firebase-fhir/src/resources/allergyIntolerance.ts
+++ b/packages/spezi-firebase-fhir/src/resources/allergyIntolerance.ts
@@ -55,7 +55,7 @@ export const untypedAllergyIntoleranceSchema = z.lazy(() =>
     identifier: identifierSchema.array().optional(),
     clinicalStatus: codeableConceptSchema.optional(),
     verificationStatus: codeableConceptSchema.optional(),
-    type: allergyIntoleranceTypeSchema,
+    type: allergyIntoleranceTypeSchema.optional(),
     _type: elementSchema.optional(),
     category: allergyIntoleranceCategorySchema.array().optional(),
     _category: elementSchema.array().optional(),


### PR DESCRIPTION
# Make AllergyIntolerance.type optional, as defined in the spec

## :recycle: Current situation & Problem
We have wrongfully made AllergyIntolerance.type non-optional. This is now fixed.


## :gear: Release Notes
- Make AllergyIntolerance.type optional.


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
